### PR TITLE
added documentation for option to place input data in data field

### DIFF
--- a/warp-academy-docs/docs/sdk/advanced/warp-extensions.md
+++ b/warp-academy-docs/docs/sdk/advanced/warp-extensions.md
@@ -2,8 +2,22 @@
 
 ### Input in data
 
-According to the [SmartWeave protocol](./smartweave-protocol.md), input of the interaction can be stored in its tags, more specifically - in the Input tag. However, we are then limited by the transaction tag’s size limit - 4kb for the transaction (including all the default tags that Warp applies). Due to this problem, a new way of storing input - in the data field of the transaction - was introduceed in Warp. It does not require any changes from the user perspective. Warp SDK checks the input size and decide wether it should be placed in the tag or - if it exceeds the limit - in the data field of the transaction. Interaction is then sent to the Warp Sequencer and indexed as usual - so it is available in all of the Warp tools as it’s been before. Particularly - contract state of the contract is evaluated regardless of the input type.
+According to the [SmartWeave protocol](./smartweave-protocol.md), input of the interaction can be stored in its tags, more specifically - in the Input tag. However, we are then limited by the transaction tag’s size limit - 4kb for the transaction (including all the default tags that Warp applies). Due to this problem, a new way of storing input - in the data field of the transaction - was introduced in Warp. It does not require any changes from the user perspective. Warp SDK checks the input size and decide wether it should be placed in the tag or - if it exceeds the limit - in the data field of the transaction. Interaction is then sent to the Warp Sequencer and indexed as usual - so it is available in all of the Warp tools as it’s been before. Particularly - contract state of the contract is evaluated regardless of the input type.
 
-A new tag - `Input-Format` has been added to the interaction. It is set to either tag or data depending on the way of storing input.
+A new tag - `Input-Format` has been added to the interaction. It is set to either tag or data depending on the size of the interaction input, defaulting to the tag field if transaction tag size is less than the 4kb limit. However, to override this default behavior and explicitly have interaction input placed in the data field, `writeInteraction` should be called with the `inputFormatAsData` option set to `true`.
+
+<details>
+  <summary>Example</summary>
+
+```typescript
+const result = await contract.writeInteraction(
+  {
+    function: "NAME_OF_YOUR_FUNCTION",
+    data: { ... },
+  },
+  { inputFormatAsData: true }
+);
+```
+</details>
 
 As of now, limit for the interaction data item is set to 20kb. New feature works only for the bundled data items (so no way of sending big inputs in Arweave L1 interactions).

--- a/warp-academy-docs/docs/sdk/basic/contract-methods.md
+++ b/warp-academy-docs/docs/sdk/basic/contract-methods.md
@@ -111,7 +111,7 @@ Writes a new "interaction" transaction - i.e. such transaction that stores input
 The interaction transactions are loaded during the contract state evaluation.
 
 - `input` the interaction input
-- `options` - an object with some custom options (see [WriteInteractionOptions](https://github.com/warp-contracts/warp/blob/main/src/contract/Contract.ts#L49))
+- `options` - an object with some custom options (see [WriteInteractionOptions](https://github.com/warp-contracts/warp/blob/main/src/contract/Contract.ts#L57))
 
 In case of the `forMainnet` and `forTestnet` obtained `Warp` instances, interaction transactions are bundled and posted on Arweave using Warp Sequencer.  
 If you want to post transactions directly to Arweave - disable bundling by setting `options.disableBundling` to `true`.


### PR DESCRIPTION
Documented the use of `inputFormatAsData` option. A feature specified in https://github.com/warp-contracts/warp/pull/520 that allows SDK users to override default behavior of placing interaction input in the transaction tags, in favor of explicitly placing their interaction input in the data field instead.